### PR TITLE
Downgrade R base to 4.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [v1.2.1](https://github.com/fboulnois/llm-leaderboard-csv/compare/v1.2.0...v1.2.1) - 2024-08-13
+
+### Fixed
+
+* Downgrade to 4.4.0 to avoid broken packages
+
 ## [v1.2.0](https://github.com/fboulnois/llm-leaderboard-csv/compare/v1.1.0...v1.2.0) - 2024-07-12
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM r-base:4.4.1 AS env-deploy
+FROM r-base:4.4.0 AS env-deploy
 
 RUN apt-get update && apt-get install -y libssl-dev libcurl4-openssl-dev libxml2-dev
 


### PR DESCRIPTION
Downgrade R base container to 4.4.0 to avoid broken packages.