### PR TITLE
Fix chatbot arena URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [v1.2.2](https://github.com/fboulnois/llm-leaderboard-csv/compare/v1.2.1...v1.2.2) - 2024-10-14
+
+### Fixed
+
+* Update lmsys arena url to new location
+
 ## [v1.2.1](https://github.com/fboulnois/llm-leaderboard-csv/compare/v1.2.0...v1.2.1) - 2024-08-13
 
 ### Fixed

--- a/huggingface.R
+++ b/huggingface.R
@@ -142,7 +142,7 @@ url <- "https://open-llm-leaderboard-old-open-llm-leaderboard.hf.space/"
 file <- "huggingface_v1.csv"
 hg1 <- dt_if_missing(file, dt_from_html_hg, url)
 
-url <- "https://lmsys-chatbot-arena-leaderboard.hf.space/"
+url <- "https://lmarena-ai-chatbot-arena-leaderboard.hf.space/"
 file <- "lmsys.csv"
 lmsys <- dt_if_missing(file, dt_from_html_lm, url)
 


### PR DESCRIPTION
Updates the chatbot (formerly LMSYS) arena URL to the new location.